### PR TITLE
Bug fix: use correct filename in script loop

### DIFF
--- a/wordlesolver.sh
+++ b/wordlesolver.sh
@@ -54,7 +54,7 @@ if [ $answer == Y ]; then
 			echo "What is letter $i"
 			read letter
 			grep -Ei "([$letter])" /tmp/words$uname >> /tmp/wordleguesses2$uname.txt
-			mv /tmp/wordleguesses2.txt /tmp/words$uname
+                        mv /tmp/wordleguesses2$uname.txt /tmp/words$uname
 			cp /tmp/words$uname /tmp/wordleguesses$uname.txt
 			((i--))
 		done


### PR DESCRIPTION
## Summary
- fix path variable for intermediary file in `wordlesolver.sh`

## Testing
- `shellcheck wordlesolver.sh`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684043e75f30832187249a32f9bf97b8